### PR TITLE
Fix hangman ASCII art definition

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,27 +2,43 @@ import random
 #random module is used to select random words from the list
 words= ["apple","banana","cherry","mango","litchi","orange","grape"]
 #creating askii art for the hangman representation
-hangman_art= {0:("   "
-                 "   "
-                 "   "),
-               1:(" 0  ",
-                  "   ",
-                  "   "),
-               2:(" 0  ",
-                  " |  ",
-                  "   "),
-                3:(" 0  ",
-                   "/|  "
-                   "   "),
-                4:(" 0  ",
-                   "/|\\ ",
-                   "   "),
-                5:(" 0  ",
-                   "/|\\ ",
-                   "/   "),
-                6:(" 0  ",
-                   "/|\\  ",
-                   "/ \\  ")}
+hangman_art = {
+    0: (
+        "   ",
+        "   ",
+        "   ",
+    ),
+    1: (
+        " 0  ",
+        "   ",
+        "   ",
+    ),
+    2: (
+        " 0  ",
+        " |  ",
+        "   ",
+    ),
+    3: (
+        " 0  ",
+        "/|  ",
+        "   ",
+    ),
+    4: (
+        " 0  ",
+        "/|\\ ",
+        "   ",
+    ),
+    5: (
+        " 0  ",
+        "/|\\ ",
+        "/   ",
+    ),
+    6: (
+        " 0  ",
+        "/|\\  ",
+        "/ \\  ",
+    ),
+}
 
 #creating functions to display hangman, answer, and hints
 


### PR DESCRIPTION
## Summary
- Ensure each hangman stage is defined as a tuple of strings so the art renders correctly

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
from main import display_hangman
for i in range(7):
    print('Stage', i)
    display_hangman(i)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b01443c10c8322af0d71f041c8e779